### PR TITLE
Let git find out where the repo is

### DIFF
--- a/legit/helpers.py
+++ b/legit/helpers.py
@@ -16,18 +16,3 @@ _platform = platform.system().lower()
 is_osx = (_platform == 'darwin')
 is_win = (_platform == 'windows')
 is_lin = (_platform == 'linux')
-
-
-def find_path_above(*names):
-    """Attempt to locate given path by searching parent dirs."""
-
-    path = '.'
-
-    while os.path.split(os.path.abspath(path))[1]:
-        for name in names:
-            joined = os.path.join(path, name)
-            if os.path.exists(joined):
-                return os.path.abspath(joined)
-        path = os.path.join('..', path)
-
-

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -9,13 +9,13 @@ This module provides the main interface to Git.
 
 import os
 import sys
+import subprocess
 from collections import namedtuple
 from operator import attrgetter
 
 from git import Repo, Git
 from git.exc import GitCommandError
 
-from .helpers import find_path_above
 from .settings import settings
 
 
@@ -208,11 +208,12 @@ def publish_branch(branch):
 def get_repo():
     """Returns the current Repo, based on path."""
 
-    bare_path = find_path_above('.git')
+    work_path = subprocess.Popen([git, 'rev-parse', '--show-toplevel'],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE).communicate()[0].rstrip('\n')
 
-    if bare_path:
-        prelapsarian_path = os.path.split(bare_path)[0]
-        return Repo(prelapsarian_path)
+    if work_path:
+        return Repo(work_path)
     else:
         return None
 


### PR DESCRIPTION
Ensures simpler code, and identical discovery method.

This should fix #9 too.
