### PR TITLE
Modified cmd_install to work on Windows

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -367,25 +367,33 @@ def cmd_settings(args):
     sys.exit()
 
 
-def cmd_install(args):
+def cmd_install(args):    
     """Installs legit git aliases."""
 
     aliases = {
-        'branches': '\'!legit branches\'',
-        'graft': '\'!legit graft "$@"\'',
-        'harvest': '\'!legit harvest "$@"\'',
-        'publish': '\'!legit publish "$@"\'',
-        'unpublish': '\'!legit unpublish "$@"\'',
-        'sprout': '\'!legit sprout "$@"\'',
-        'sync': '\'!legit sync "$@"\'',
-        'switch': '\'!legit switch "$@"\'',
+        'branches': '!legit branches',
+        'graft': '!legit graft "$@"',
+        'harvest': '!legit harvest "$@"',
+        'publish': '!legit publish "$@"',
+        'unpublish': '!legit unpublish "$@"',
+        'sprout': '!legit sprout "$@"',
+        'sync': '!legit sync "$@"',
+        'switch': '!legit switch "$@"'
     }
 
     print 'The following git aliases have been installed:\n'
 
     for (ak, av) in aliases.items():
-        os.system('git config --global --replace-all alias.{0} {1}'.format(ak, av))
-        print columns(['', 1], [colored.yellow('git ' + ak), 14], [av, None])
+        args = [
+            'git',
+            'config',
+            '--global',
+            '--replace-all',
+            'alias.' + ak,
+            av]
+
+        if 0 == call(args, shell=True):
+            print columns(['', 1], [colored.yellow('git ' + ak), 14], [av, None])
 
     sys.exit()
 


### PR DESCRIPTION
I found that on windows, the os.system() call always results in git complaining about "invalid number of arguments". I modified cmd_install() to use an argument-list approach and just delegate escaping to subprocess, which seems to work better.
