### PR TITLE
Handle detached head in legit branches

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -441,8 +441,13 @@ def display_available_branches():
 
     for branch in branches:
 
-        marker = '*' if (branch.name == repo.head.ref.name) else ' '
-        color = colored.green if (branch.name == repo.head.ref.name) else colored.yellow
+        try:
+            branch_is_selected = (branch.name == repo.head.ref.name)
+        except TypeError:
+            branch_is_selected = False
+
+        marker = '*' if branch_is_selected else ' '
+        color = colored.green if branch_is_selected else colored.yellow
         pub = '(published)' if branch.is_published else '(unpublished)'
 
         print columns(


### PR DESCRIPTION
Currently, if you call 'legit branches' in a git repo that has a detached head, you get this:

```
Traceback (most recent call last):
  File "/Users/offline/virtualenv/legit/bin/legit", line 8, in <module>
    load_entry_point('legit==0.1.0', 'console_scripts', 'legit')()
  File "/Users/offline/projects/legit/legit/cli.py", line 45, in main
    cmd_map.get(arg).__call__(args)
  File "/Users/offline/projects/legit/legit/cli.py", line 337, in cmd_branches
    display_available_branches()
  File "/Users/offline/projects/legit/legit/cli.py", line 444, in display_available_branches
    marker = '*' if (branch.name == repo.head.ref.name) else ' '
  File "/Users/offline/virtualenv/legit/lib/python2.7/site-packages/GitPython-0.3.2.RC1-py2.7.egg/git/refs/symbolic.py", line 244, in _get_reference
    raise TypeError("%s is a detached symbolic reference as it points to %r" % (self, sha))
TypeError: HEAD is a detached symbolic reference as it points to '6ad8bad03bb47b65c6c633562a8cae082844b9cf'
```

Obviously, suboptimal.

That's fixed by this pull request.
