### PR TITLE
Fix AttributeError on merge conflict

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -507,7 +507,7 @@ def display_version():
 
 def handle_abort(aborted):
     print colored.red('Error:'), aborted.message
-    print black(aborted.log)
+    print black(str(aborted.log))
     print 'Unfortunately, there was a merge conflict. It has to be merged manually.'
     sys.exit(1)
 


### PR DESCRIPTION
Whenever I get a merge conflict, legit pukes up an exception as in the example below.

Since black() looks to be expecting a str, let's give it one.

<pre>
$ legit sync
Pulling commits from the server.
Error: Merge failed. Reverting.
Traceback (most recent call last):
  File "/usr/bin/legit", line 9, in <module>
    load_entry_point('legit==0.1.1', 'console_scripts', 'legit')()
  File "/usr/lib/python2.7/site-packages/legit/cli.py", line 45, in main
    cmd_map.get(arg).__call__(args)
  File "/usr/lib/python2.7/site-packages/legit/cli.py", line 158, in cmd_sync
    status_log(smart_pull, 'Pulling commits from the server.')
  File "/usr/lib/python2.7/site-packages/legit/cli.py", line 80, in status_log
    log = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/legit/scm.py", line 119, in smart_pull
    return smart_merge('{0}/{1}'.format(remote, branch))
  File "/usr/lib/python2.7/site-packages/legit/scm.py", line 140, in smart_merge
    abort('Merge failed. Reverting.', log=why)
  File "/usr/lib/python2.7/site-packages/legit/scm.py", line 42, in abort
    settings.abort_handler(a)
  File "/usr/lib/python2.7/site-packages/legit/cli.py", line 489, in handle_abort
    print black(aborted.log)
  File "/usr/lib/python2.7/site-packages/legit/cli.py", line 29, in black
    return s.encode('utf-8')
AttributeError: 'GitCommandError' object has no attribute 'encode'
</pre>
