### PR TITLE
Fix incorrect stash pop index

### DIFF
--- a/legit/scm.py
+++ b/legit/scm.py
@@ -97,7 +97,7 @@ def unstash_it(sync=False):
 
     if stash_index is not None:
         return repo.git.execute([git,
-            'stash', 'pop', 'stash@{{0}}'.format(stash_index)])
+            'stash', 'pop', 'stash@{{{0}}}'.format(stash_index)])
 
 
 def fetch():


### PR DESCRIPTION
The old code `'stash@{{0}}'.format(stash_index)` escaped the braces, resulting in the first stash always being popped.

I've mentioned this in comments in #59 and #7, and this probably fixes #59
