### PR TITLE
Add bash tab-completion for git-aliased legit

### DIFF
--- a/extra/bash-completion/legit
+++ b/extra/bash-completion/legit
@@ -5,30 +5,26 @@ _legit()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
     opts="branches graft publish sprout switch sync unpublish"
+    local running=`git for-each-ref --format='%(refname:short)' --sort='refname:short' refs/heads`
 
     case "${prev}" in
         sync)
-            local running=$(for x in `git branch`; do echo ${x} ; done )
             COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
             return 0
             ;;
         switch)
-            local running=$(for x in `git branch`; do echo ${x} ; done )
             COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
             return 0
             ;;
         sprout)
-            local running=$(for x in `git branch`; do echo ${x} ; done )
             COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
             return 0
             ;;
         graft)
-            local running=$(for x in `git branch`; do echo ${x} ; done )
             COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
             return 0
             ;;
         publish)
-            local running=$(for x in `git branch`; do echo ${x} ; done )
             COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
             return 0
             ;;
@@ -62,7 +58,7 @@ _git_unpublish()
 _complete_with_git_branch()
 {
     local cur="${COMP_WORDS[COMP_CWORD]}"
-    local running=$(for x in `git branch`; do echo ${x} ; done )
+    local running=`git for-each-ref --format='%(refname:short)' --sort='refname:short' refs/heads`
     COMPREPLY=( $(compgen -W "${running}" -- ${cur}) )
     return 0
 }


### PR DESCRIPTION
The existing tab-completion script doesn't work when `legit` is used via git aliases (such as `git switch <tab>`). This patch makes that work for bash. Not very pretty, but does the job =)
