### PR TITLE
Preventing errors in a new repo with no branches or remotes

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -436,6 +436,10 @@ def display_available_branches():
 
     branches = get_branches()
 
+    if not branches:
+        print colored.red('No branches available')
+        return
+
     branch_col = len(max([b.name for b in branches], key=len)) + 1
 
     for branch in branches:

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -219,8 +219,8 @@ def get_repo():
 
 
 def get_remote():
-    
-    repo_check()
+
+    repo_check(require_remote=True)
 
     reader = repo.config_reader()
 
@@ -257,7 +257,7 @@ def get_branches(local=True, remote_branches=True):
 
                 if name not in settings.forbidden_branches:
                     branches.append(Branch(name, True))
-        except IndexError:
+        except (IndexError, AssertionError):
             pass
 
     if local:


### PR DESCRIPTION
I tried legit for the first time and it was natural to me to do

```
mcd /tmp/wut
git init
legit install
```

I got some problems:
- With legit from pip `legit install` worked well but then a simple command like `git branches` failed hard with an ugly exception (I added an error message for that)
- With legit from your repo `legit install` raised an exception as there were no remotes and there's a piece of code in scm.py that calls `remote = get_remote()`. I added a fake remote without pulling or fetching, `git branches` failed like in the previous point for an `AssertionError` because of `for b in remote.refs:`

I fixed those problems adding a meaningful error message
