### PR TITLE
Fix auto-merge code so that rebase will be called

### DIFF
--- a/legit/scm.py
+++ b/legit/scm.py
@@ -129,7 +129,7 @@ def smart_merge(branch, allow_rebase=True):
         'log', '--merges', '{0}..{1}'.format(branch, from_branch)])
 
     if allow_rebase:
-        verb = 'merge' if len(merges.split('commit')) else 'rebase'
+        verb = 'merge' if merges.count('commit') else 'rebase'
     else:
         verb = 'merge'
 


### PR DESCRIPTION
Use count instead of split to count commits

string.split will return a list with one element (the original string) if the delimiter is not found

fix issue #62
