### PR TITLE
Fix synopsis for the sprout command in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ The Interface
     Defaults to current branch.
     Automatically stashes and unstashes any changes.
 
-``sprout <branch> <new-branch>``
+``sprout [<branch>] <new-branch>``
     Creates a new branch off of the specified branch.
     Swiches to it immediately.
 


### PR DESCRIPTION
Just fixed the synopsis for the sprout command in the README file. The `<branch>` argument is optional, defaulting to the current branch..
