### PR TITLE
allow to specify a remote in the publish command

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -174,15 +174,17 @@ def sync(ctx, scm, to_branch, verbose, fake):
 
 
 @cli.command(short_help='Publishes specified branch to the remote.')
+@click.argument('remote', required=False)
 @click.argument('to_branch', required=False)
 @click.option('--verbose', is_flag=True, help='Enables verbose mode.')
 @click.option('--fake', is_flag=True, help='Show but do not invoke git commands.')
 @pass_scm
-def publish(scm, to_branch, verbose, fake):
+def publish(scm, remote, to_branch, verbose, fake):
     """Pushes an unpublished branch to a remote repository."""
     scm.fake = fake
     scm.verbose = fake or verbose
 
+    remote = remote or scm.remote.name
     scm.repo_check(require_remote=True)
     branch = scm.fuzzy_match_branch(to_branch)
 
@@ -204,7 +206,7 @@ def publish(scm, to_branch, verbose, fake):
             .format(crayons.yellow(branch)))
 
     status_log(scm.publish_branch, 'Publishing {0}.'.format(
-        crayons.yellow(branch)), branch)
+        crayons.yellow(branch)), remote, branch)
 
 
 @cli.command(short_help='Removes specified branch from the remote.')

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -211,11 +211,11 @@ class SCMRepo(object):
                 with_extended_output=True)
             abort('Unpublish failed. Fetching.', log=log, type='unpublish')
 
-    def publish_branch(self, branch):
+    def publish_branch(self, remote, branch):
         """Publishes given branch."""
 
         return self.git_exec(
-            ['push', '-u', self.remote.name, branch])
+            ['push', '-u', remote, branch])
 
     def undo(self, hard=False):
         """Makes last commit not exist"""

--- a/legit/tests/test_commands.py
+++ b/legit/tests/test_commands.py
@@ -84,7 +84,7 @@ class TestLegit(object):
     def test_publish(self):
         """Test publish command"""
         runner = CliRunner()
-        result = runner.invoke(cli, ['publish', 'kenneth', '--fake'])
+        result = runner.invoke(cli, ['publish', 'origin', 'kenneth', '--fake'])
         assert result.exit_code == 0
         assert 'Publishing kenneth' in result.output
         assert 'Faked!' in result.output
@@ -93,7 +93,7 @@ class TestLegit(object):
     def test_pub(self):
         """Test publish alias pub"""
         runner = CliRunner()
-        result = runner.invoke(cli, ['pub', 'kenneth', '--fake'])
+        result = runner.invoke(cli, ['pub', 'origin', 'kenneth', '--fake'])
         assert result.exit_code == 0
         assert 'Publishing kenneth' in result.output
         assert 'Faked!' in result.output
@@ -102,7 +102,7 @@ class TestLegit(object):
     def test_publish_published_branch(self):
         """Test publish command with published branch"""
         runner = CliRunner()
-        result = runner.invoke(cli, ['publish', 'develop', '--fake'])
+        result = runner.invoke(cli, ['publish', 'origin', 'develop', '--fake'])
         assert result.exit_code == 2
         assert "Branch develop is already published." in result.output
         assert 'Faked!' not in result.output


### PR DESCRIPTION
this is especially useful when working with github's hub (https://github.com/github/hub),
to submit a pull request:

    git clone git@github.com:kennethreitz/legit.git
	git checkout -b my_branch
	# code
	git commit -am "my changes"
	git fork
	git publish glehmann
	git pull-request