### PR TITLE
Allow wildcard matching for "branches" command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,8 +41,9 @@ The Interface
 ``undo``
     Un-does the last commit in git history.  (alias: ``un``)
 
-``branches``
+``branches [<wildcard pattern>]``
     Display a list of available branches.
+    Allows wildcard pattern matching of branch name.
 
 
 The Installation

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@
 <span class=ig>$ </span>git unpublish &lt;branch&gt;
 <span class=ig># Removes branch from remote server.</span>
 
-<span class=ig>$ </span>git branches
+<span class=ig>$ </span>git branches [wildcard pattern]
 <span class=ig># Nice &amp; pretty list of branches + publication status.</span>
 
 <span class=ig>$ </span>git undo [--hard]

--- a/extra/man/legit.1
+++ b/extra/man/legit.1
@@ -2,7 +2,7 @@
 .
 .TH LEGIT: GIT FOR HUMANS  "" "" ""
 .SH NAME
-Legit: Git for Humans \- 
+Legit: Git for Humans \-
 .
 .nr rst2man-indent-level 0
 .
@@ -50,8 +50,9 @@ Why not bring this innovation back to the command line?
 .SH THE INTERFACE
 .INDENT 0.0
 .TP
-.B \fBbranches\fP
+.B \fBbranches [<wildcard pattern>]\fP
 Get a nice pretty list of available branches.
+Allows wildcard branch name matching.
 .TP
 .B \fBsync [<branch>]\fP
 Synchronizes the given branch. Defaults to current branch.

--- a/extra/zsh-completion/_legit
+++ b/extra/zsh-completion/_legit
@@ -26,7 +26,7 @@ _legit ()
         local -a subcommands
         subcommands=(
                 'settings: Display and edit the current Legit settings.'
-                'branches: Get a nice pretty list of available branches.'
+                'branches: Get a nice pretty list of available branches. Allows wildcard branch name matching.'
                 'sync: Synchronizes the given branch. Defaults to current branch. Stash, Fetch, Auto-Merge/Rebase, Push, and Unstash. You can only sync published branches.'
                 'switch: Switches to specified branch. Defaults to current branch. Automatically stashes and unstashes any changes.'
                 'publish: Publishes specified branch to the remote.'

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -253,12 +253,16 @@ def undo(scm, verbose, fake, hard):
 
 
 @cli.command()
+@click.argument('wildcard_pattern', required=False)
 @pass_scm
-def branches(scm):
+def branches(scm, wildcard_pattern):
     """Displays a list of branches."""
     scm.repo_check()
 
-    scm.display_available_branches()
+    if wildcard_pattern:
+        scm.display_available_branches(wildcard_pattern)
+    else:
+        scm.display_available_branches()
 
 
 def do_install(ctx, verbose, fake):

--- a/legit/tests/test_commands.py
+++ b/legit/tests/test_commands.py
@@ -193,6 +193,13 @@ def test_config(runner):
 
 @pytest.mark.cli
 def test_branches(runner):
-    """Test undo alias un"""
+    """Test branches command"""
     result = runner.invoke(cli, ["branches"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.cli
+def test_branches_with_wildcard(runner):
+    """Test branches command with wildcard filename pattern"""
+    result = runner.invoke(cli, ["branches", "ma*"])
     assert result.exit_code == 0

--- a/legit/utils.py
+++ b/legit/utils.py
@@ -99,6 +99,9 @@ $ {4}
 Unpublish a specific branch from remote:
 $ {5}
 
+List branches matching wildcard pattern:
+$ {6}
+
 Commands:""".format(
             crayons.red('legit switch <branch>'),
             crayons.red('legit sync'),
@@ -106,6 +109,7 @@ Commands:""".format(
             crayons.red('legit publish'),
             crayons.red('legit publish <branch>'),
             crayons.red('legit unpublish <branch>'),
+            crayons.red('legit branches [<wildcard pattern>]'),
         )
 
     help = help.replace('Commands:', additional_help)


### PR DESCRIPTION
This update adds branch name wildcard pattern matching to the "branches" command.
The use case is when a repository has many active branches and you just want to see branches matching a particular naming pattern.

The branch name wildcard patterns follow Unix filename pattern matching standards (from documentation for `fnmatch`):

 Pattern | Meaning
 ------- | --------
 \* | matches everything
 \? | matches any single character
 [seq] | matches any character in seq
 [!seq] | matches any character not in seq

For a literal match, wrap the meta-characters in brackets. For example, '[?]' matches the character '?'.

### Examples

#### `branches` without wildcard:

```shell
$ git branches
   develop               (published)
*  gu-branches-wildcard  (published)
   master                (published)
```

#### `branches` with wildcard:

```shell
$ git branches gu*
*  gu-branches-wildcard  (published)
```