### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python setup.py install ; legit"

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,9 @@ The Installation
 .. image:: https://img.shields.io/coveralls/github/frostming/legit.svg
     :target: https://coveralls.io/r/frostming/legit/
 
+.. image:: https://repl.it/badge/github/frostming/legit
+    :target: https://repl.it/github/frostming/legit
+
 
 From `PyPI <https://pypi.python.org/pypi/legit/>`_ with the Python package manager::
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.It adds a `.replit` configuration file and a Repl.it badge to the `README`. This will allow viewers of the repository to click the run on Repl.it button and be able to use ddgr inside the Repl.it environment.
You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/legit).