### PR TITLE
Drop support for EOL Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ language: python
 dist: xenial
 cache: pip
 python:
-  - 2.7
   - 3.5
   - 3.6
   - 3.7

--- a/legit/__init__.py
+++ b/legit/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-
 from .core import *  # noqa

--- a/legit/bootstrap.py
+++ b/legit/bootstrap.py
@@ -9,7 +9,7 @@ This module boostraps the Legit runtime.
 from clint import resources
 from clint.textui import colored
 import crayons
-from six.moves import configparser
+import configparser
 
 from .settings import legit_settings
 
@@ -24,11 +24,7 @@ except OSError:
 
 # Load existing configuration.
 config = configparser.ConfigParser()
-try:
-    # `read_file()` added in Python 3.2
-    config.read_file(config_file)
-except AttributeError:
-    config.readfp(config_file)
+config.read_file(config_file)
 
 
 # Populate if needed.

--- a/legit/bootstrap.py
+++ b/legit/bootstrap.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 legit.bootstrap
 ~~~~~~~~~~~~~~~
@@ -19,7 +17,7 @@ resources.init('kennethreitz', 'legit')
 
 try:
     config_file = resources.user.open('config.ini', 'r')
-except IOError:
+except OSError:
     resources.user.write('config.ini', '')
     config_file = resources.user.open('config.ini', 'r')
 

--- a/legit/cli.py
+++ b/legit/cli.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 legit.cli
 ~~~~~~~~~
@@ -38,7 +36,7 @@ class LegitGroup(click.Group):
 
     def list_commands(self, ctx):
         """Override for showing commands in particular order"""
-        commands = super(LegitGroup, self).list_commands(ctx)
+        commands = super().list_commands(ctx)
         return [cmd for cmd in order_manually(commands)]
 
     def get_command(self, ctx, cmd_name):

--- a/legit/core.py
+++ b/legit/core.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 legit.core
 ~~~~~~~~~~

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 legit.scm
 ~~~~~~~~~
@@ -28,7 +26,7 @@ LEGIT_TEMPLATE = 'Legit: stashing before {0}.'
 Branch = namedtuple('Branch', ['name', 'is_published'])
 
 
-class SCMRepo(object):
+class SCMRepo:
     git = None
     repo = None
     remote = None
@@ -373,7 +371,7 @@ def fallback_enabled(reader):
         return False
 
 
-class Aborted(object):
+class Aborted:
 
     def __init__(self):
         self.message = None

--- a/legit/settings.py
+++ b/legit/settings.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """
 legit.config
 ~~~~~~~~~~~~~~~~~~
@@ -9,14 +7,14 @@ This module provides the Legit settings feature set.
 """
 
 
-class Settings(object):
+class Settings:
     _singleton = {}
 
     # attributes with defaults
     __attrs__ = tuple()
 
     def __init__(self, **kwargs):
-        super(Settings, self).__init__()
+        super().__init__()
 
         self.__dict__ = self._singleton
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ settings.update(
         'clint',
         'crayons',
         'GitPython',
-        'six'
     ],
     license="BSD",
     python_requires=">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -80,20 +80,19 @@ settings.update(
         'six'
     ],
     license="BSD",
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3 :: Only",
     ],
     entry_points={"console_scripts": ["legit = legit.cli:cli"]},
     cmdclass={"publish": UploadCommand}

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist =
     checkqa
-    py27
     py35
     py36
     py37


### PR DESCRIPTION
Drop Python 2.7, which has been end-of-life for a year.