### PR TITLE
Control errors when working on empty repo

### DIFF
--- a/legit/cli.py
+++ b/legit/cli.py
@@ -245,7 +245,7 @@ def undo(scm, verbose, fake, hard):
     scm.fake = fake
     scm.verbose = fake or verbose
 
-    scm.repo_check()
+    scm.repo_check(require_refs=True)
 
     status_log(scm.undo, 'Last commit removed from history.', hard)
 

--- a/legit/scm.py
+++ b/legit/scm.py
@@ -15,7 +15,7 @@ import click
 from clint.textui import colored, columns
 import crayons
 from git import Repo
-from git.exc import GitCommandError, InvalidGitRepositoryError
+from git.exc import BadName, GitCommandError, InvalidGitRepositoryError
 
 from .settings import legit_settings
 from .utils import black, status_log
@@ -63,10 +63,21 @@ class SCMRepo:
                 result = ''
         return result
 
-    def repo_check(self, require_remote=False):
+    def repo_check(self, require_remote=False, require_refs=False):
         if self.repo is None:
             click.echo('Not a git repository.')
             sys.exit(128)
+
+        if self.repo.heads == []:
+            click.echo('Repo is empty.')
+            sys.exit(128)
+
+        if require_refs:
+            try:
+                self.repo.commit('HEAD^')
+            except BadName:
+                click.echo('Repo only contains root commit.')
+                sys.exit(128)
 
         # TODO: no remote fail
         if not self.repo.remotes and require_remote:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ universal=1
 
 [tool:pytest]
 addopts = -v -x --ignore=setup.py --cov=legit
+markers = 
+  cli: Cli command related tests


### PR DESCRIPTION
When we try to use legit over an initialized
but empty repo it breaks with an stacktrace.

Now we control that the repo has at least one head
and for 'undo' command also that we have at least
two commits on the branch. This is needed because
'git reset' cannot work on empty repo or undo
'root' commit.

Also added a chore fix to remove pytest warnings about
marks used but not registered.