### PR TITLE
doc: change switch to sw

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,18 @@ If you want to see the git commands used by legit but don't want them invoked, u
 
     legit publish --fake
 
+Legit Options
+-------------
+
+By default, ``legit sync`` avoids a true merge.
+If the merge is not fast-forward, legit will rebase.
+
+In gitconfig, if ``legit.smartMerge`` is set to false,
+and ``pull.rebase`` is set to false or unset,
+then legit will not rebase but merge.
+
+If ``legit.smartMerge`` is set to false, and ``pull.ff`` is set to ``only``,
+then if the merge is not fast-forward, legit will abort.
 
 Caveats
 -------

--- a/README.rst
+++ b/README.rst
@@ -22,10 +22,10 @@ Why not bring this innovation back to the command line?
 The Interface
 -------------
 
-``switch <branch>``
+``sw <branch>``
     Switches to specified branch.
     Defaults to current branch.
-    Automatically stashes and unstashes any changes. (alias: ``sw``)
+    Automatically stashes and unstashes any changes. (alias: ``switch`` for git < 2.23)
 
 ``sync [<branch>]``
     Synchronizes the given branch. Defaults to current branch.

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,7 +48,7 @@
 <span class=ig>$ </span>git sync
 <span class=ig># Synchronizes current branch. Auto-merge/rebase, un/stash.</span>
 
-<span class=ig>$ </span>git publish &lt;branch&gt;
+<span class=ig>$ </span>git publish [&lt;branch&gt;]
 <span class=ig># Publishes branch to remote server.</span>
 
 <span class=ig>$ </span>git unpublish &lt;branch&gt;

--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
   <h2>Git Workflow for Humans</h2>
   <p>Feature branch workflows are dead simple.</p>
   <pre>
-<span class=ig>$ </span>git switch &lt;branch&gt;
+<span class=ig>$ </span>git sw &lt;branch&gt;
 <span class=ig># Switches to branch. Stashes and restores unstaged changes.</span>
 
 <span class=ig>$ </span>git sync

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
   src="http://s3.amazonaws.com/github/ribbons/forkme_right_gray_6d6d6d.png" alt="Fork me on GitHub"></a>
 
   <p class=footer>
-    &copy; Copyright 2017. A <a href='https://www.kennethreitz.org/projects'>Kenneth Reitz</a> Project.
+    &copy; Copyright 2017–2022. Originally a <a href='https://www.kennethreitz.org/projects'>Kenneth Reitz</a> Project.
 </div>
 <script type="text/javascript">
   var _gauges = _gauges || [];

--- a/extra/man/legit.1
+++ b/extra/man/legit.1
@@ -59,7 +59,7 @@ Synchronizes the given branch. Defaults to current branch.
 Stash, Fetch, Auto\-Merge/Rebase, Push, and Unstash.
 You can only sync published branches.
 .TP
-.B \fBswitch <branch>\fP
+.B \fBsw <branch>\fP
 Switches to specified branch.
 Defaults to current branch.
 Automatically stashes and unstashes any changes.

--- a/legit/utils.py
+++ b/legit/utils.py
@@ -103,7 +103,7 @@ List branches matching wildcard pattern:
 $ {}
 
 Commands:""".format(
-            crayons.red('legit switch <branch>'),
+            crayons.red('legit sw <branch>'),
             crayons.red('legit sync'),
             crayons.red('legit sync <branch>'),
             crayons.red('legit publish'),


### PR DESCRIPTION
switch confilicts with the switch command introduced by git 2.23, and the alias is not installed for git >= 2.23.
Thus, the documentation is updated to encourage using sw instead.

see also #256